### PR TITLE
Update Chinese translation

### DIFF
--- a/build/_locales/zh_CN/messages.json
+++ b/build/_locales/zh_CN/messages.json
@@ -53,9 +53,9 @@
         "message": "LL, dddd"
     },
     "options_time_12_24": {
-        "message": "使用24小时格式"
+        "message": "使用 24 小时制"
     },
     "options_display_time_before_title": {
-        "message": "标题前显示时间"
+        "message": "时间显示在标题之前"
     }
 }


### PR DESCRIPTION
@dragonofmercy 

Here are some missing entries that were probably hardcoded:
- `Created by DragonOfMercy` → `作者：DragonOfMercy`
- `Options` (button and dialog box title) → `设置`
- `Save` (dialog box button) → `保存`

And translation for the store page description:
```Dragon Better History replaces Edge's history viewer with a more simple view. You can navigate directly while using the calendar.```
↓
```将 Edge 默认的历史记录查看器替换成 Dragon 历史记录，使用起来更便捷。你可以在日历上快速跳转。```
